### PR TITLE
[feat] 웹서버 만들기 1주차 3단계: GET으로 회원가입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,8 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### etc
+*.xml
+*.iml
+
 # End of https://www.toptal.com/developers/gitignore/api/gradle,intellij,java,macos

--- a/src/main/java/handler/UserHandler.java
+++ b/src/main/java/handler/UserHandler.java
@@ -16,10 +16,11 @@ public class UserHandler {
         return instance;
     }
 
-    public void createUser(Map<String, String> params) {
+    public User createUser(Map<String, String> params) {
         User user = User.from(params);
         Database.addUser(user);
         System.out.println("New " + user);
+        return user;
     }
 
     // 추후 update, read, delete 추가 가능

--- a/src/main/java/handler/UserHandler.java
+++ b/src/main/java/handler/UserHandler.java
@@ -1,0 +1,26 @@
+package handler;
+
+import db.Database;
+import model.User;
+
+import java.util.Map;
+
+public class UserHandler {
+
+    private static UserHandler instance = null;
+
+    public static UserHandler getInstance() {
+        if (instance == null) {
+            instance = new UserHandler();
+        }
+        return instance;
+    }
+
+    public void createUser(Map<String, String> params) {
+        User user = User.from(params);
+        Database.addUser(user);
+        System.out.println("New " + user);
+    }
+
+    // 추후 update, read, delete 추가 가능
+}

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,16 +1,22 @@
 package model;
 
+import java.util.Map;
+
 public class User {
     private String userId;
     private String password;
     private String name;
     private String email;
 
-    public User(String userId, String password, String name, String email) {
+    protected User(String userId, String password, String name, String email) {
         this.userId = userId;
         this.password = password;
         this.name = name;
         this.email = email;
+    }
+
+    public static User from(Map<String, String> params){
+        return new User(params.get("userId"), params.get("password"), params.get("name"), params.get("email"));
     }
 
     public String getUserId() {

--- a/src/main/java/util/ContentType.java
+++ b/src/main/java/util/ContentType.java
@@ -27,4 +27,8 @@ public enum ContentType {
         }
         return null;
     }
+
+    public String getExtension() {
+        return extension;
+    }
 }

--- a/src/main/java/util/FileUtil.java
+++ b/src/main/java/util/FileUtil.java
@@ -8,15 +8,27 @@ public class FileUtil {
     private FileUtil() {
     }
 
-    private static final String STATIC_PATH = "src/main/resources/static";
+    public static final String STATIC_PATH = "src/main/resources/static";
+
+    public static boolean isDirectory(String path) {
+        File file = new File(path);
+        return file.isDirectory();
+    }
 
     public static byte[] readBytesFromFile(String path) throws IOException {
-        File file = new File(STATIC_PATH + path);
-        int lengthOfBodyContent = (int) file.length();
-        byte[] body = new byte[lengthOfBodyContent];
-        try (FileInputStream fis = new FileInputStream(file); BufferedInputStream bis = new BufferedInputStream(fis)) {
-            bis.read(body);
+        try {
+            File file = new File(path);
+            if(file.isDirectory()){
+                file = new File(path + "/index.html");
+            }
+            int lengthOfBodyContent = (int) file.length();
+            byte[] body = new byte[lengthOfBodyContent];
+            try (FileInputStream fis = new FileInputStream(file); BufferedInputStream bis = new BufferedInputStream(fis)) {
+                bis.read(body);
+            }
+            return body;
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException();
         }
-        return body;
     }
 }

--- a/src/main/java/util/HttpRequestObject.java
+++ b/src/main/java/util/HttpRequestObject.java
@@ -1,28 +1,49 @@
 package util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class HttpRequestObject {
 
-    private final String requestMethod;
-    private final String requestURI;
-    private final String httpVersion;
+    private String requestMethod;
+    private String requestPath;
+    private Map<String, String> requestParams;
+    private String httpVersion;
 
-    private HttpRequestObject(String requestMethod, String requestURI, String httpVersion){
+    private HttpRequestObject(String requestMethod, String requestPath, Map<String, String> requestParams, String httpVersion) {
         this.requestMethod = requestMethod;
-        this.requestURI = requestURI;
+        this.requestPath = requestPath;
+        this.requestParams = requestParams;
         this.httpVersion = httpVersion;
     }
 
     public static HttpRequestObject from(String requestLine) {
         String[] requestLineElements = requestLine.split(" ");
-        return new HttpRequestObject(requestLineElements[0], requestLineElements[1], requestLineElements[2]);
+        String requestMethod = requestLineElements[0];
+        String[] requestURIElements = requestLineElements[1].split("\\?"); // requestURI[0]: path, requestURI[1]: params
+        String requestPath = requestURIElements[0];
+        Map<String, String> requestParams = new HashMap<>();
+        if(requestURIElements.length > 1) {
+            String[] params = requestURIElements[1].split("&");
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                requestParams.put(keyValue[0], keyValue[1]);
+            }
+        }
+        String requestVersion = requestLineElements[2];
+        return new HttpRequestObject(requestMethod, requestPath, requestParams, requestVersion);
     }
 
     public String getRequestMethod() {
         return requestMethod;
     }
 
-    public String getRequestURI() {
-        return requestURI;
+    public String getRequestPath() {
+        return requestPath;
+    }
+
+    public Map<String, String> getRequestParams() {
+        return requestParams;
     }
 
     public String getHttpVersion() {

--- a/src/main/java/util/HttpRequestObject.java
+++ b/src/main/java/util/HttpRequestObject.java
@@ -12,7 +12,8 @@ public class HttpRequestObject {
         this.httpVersion = httpVersion;
     }
 
-    public static HttpRequestObject from(String[] requestLineElements) {
+    public static HttpRequestObject from(String requestLine) {
+        String[] requestLineElements = requestLine.split(" ");
         return new HttpRequestObject(requestLineElements[0], requestLineElements[1], requestLineElements[2]);
     }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -41,20 +41,13 @@ public class RequestHandler implements Runnable {
 
     private void frontRequestProcess(OutputStream out, HttpRequestObject httpRequestObject) throws IOException {
         String path = httpRequestObject.getRequestPath();
-        if(path.equals("/user/create")) {
+        if(path.equals("/user/create") && httpRequestObject.getRequestMethod().equals("GET")) {
             userRequestProcess.createUser(httpRequestObject);
-            dynamicResponse(out, httpRequestObject);
+            response302Header(new DataOutputStream(out), "/index.html");
+            return;
         }
-        else {
-            staticResponse(out, httpRequestObject);
-        }
-    }
 
-    private void dynamicResponse(OutputStream out, HttpRequestObject httpRequestObject) throws IOException {
-        DataOutputStream dos = new DataOutputStream(out);
-        byte[] body = FileUtil.readBytesFromFile(FileUtil.STATIC_PATH + "/index.html");
-        response200Header(dos, body.length, ContentType.HTML.getExtension());
-        responseBody(dos, body);
+        staticResponse(out, httpRequestObject);
     }
 
     private void staticResponse(OutputStream out, HttpRequestObject httpRequestObject) throws IOException {
@@ -70,6 +63,16 @@ public class RequestHandler implements Runnable {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
             dos.writeBytes("Content-Type: " + ContentType.getType(extension) + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private void response302Header(DataOutputStream dos, String location) {
+        try {
+            dos.writeBytes("HTTP/1.1 302 Found \r\n");
+            dos.writeBytes("Location: " + location + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.FileUtil;
 import util.HttpRequestObject;
-import util.HttpRequestParser;
 import util.ContentType;
 
 public class RequestHandler implements Runnable {
@@ -27,14 +26,11 @@ public class RequestHandler implements Runnable {
              BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"))) {
             // 요청 Header 출력
             String line = br.readLine(); // Request Line (ex: "GET /index.html HTTP/1.1")
-            String[] requestLineElements = HttpRequestParser.parseRequestLine(line);
+            HttpRequestObject httpRequestObject = HttpRequestObject.from(line);
             while(!line.isEmpty()) {
                 logger.debug("header: {}", line);
                 line = br.readLine();
             }
-
-            // HttpRequestObject 생성
-            HttpRequestObject httpRequestObject = HttpRequestObject.from(requestLineElements);
 
             // 데이터 입출력 및 응답
             DataOutputStream dos = new DataOutputStream(out);

--- a/src/main/java/webserver/UserRequestProcess.java
+++ b/src/main/java/webserver/UserRequestProcess.java
@@ -1,6 +1,7 @@
 package webserver;
 
 import handler.UserHandler;
+import model.User;
 import util.HttpRequestObject;
 
 public class UserRequestProcess {
@@ -19,7 +20,7 @@ public class UserRequestProcess {
         this.userHandler = UserHandler.getInstance();
     }
 
-    public void createUser(HttpRequestObject httpRequestObject) {
-        userHandler.createUser(httpRequestObject.getRequestParams());
+    public User createUser(HttpRequestObject httpRequestObject) {
+        return userHandler.createUser(httpRequestObject.getRequestParams());
     }
 }

--- a/src/main/java/webserver/UserRequestProcess.java
+++ b/src/main/java/webserver/UserRequestProcess.java
@@ -1,0 +1,25 @@
+package webserver;
+
+import handler.UserHandler;
+import util.HttpRequestObject;
+
+public class UserRequestProcess {
+
+    private static UserRequestProcess instance = null;
+    private final UserHandler userHandler;
+
+    public static UserRequestProcess getInstance() {
+        if (instance == null) {
+            instance = new UserRequestProcess();
+        }
+        return instance;
+    }
+
+    private UserRequestProcess() {
+        this.userHandler = UserHandler.getInstance();
+    }
+
+    public void createUser(HttpRequestObject httpRequestObject) {
+        userHandler.createUser(httpRequestObject.getRequestParams());
+    }
+}

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,13 +23,15 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form class="form" method="get" action="/user/create" >
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
+              type="text"
+              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -38,6 +40,17 @@
               class="input_textfield"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
+              type="text"
+              name="name"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">이메일</p>
+            <input
+                    class="input_textfield"
+                    placeholder="이메일을 입력해주세요"
+                    type="text"
+                    name="email"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -47,16 +60,16 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
+              name="password"
             />
           </div>
-          <button
+          <input
             id="registration-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
-          >
-            회원가입
-          </button>
+            value="회원가입"
+            type="submit"
+          />
         </form>
       </div>
     </div>

--- a/src/test/handler/UserHandlerTest.java
+++ b/src/test/handler/UserHandlerTest.java
@@ -1,0 +1,41 @@
+package handler;
+
+import model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserHandlerTest {
+
+    UserHandler userHandler;
+
+    @BeforeEach
+    void setUp() {
+        userHandler = UserHandler.getInstance();
+    }
+
+    @DisplayName("requestParams를 받아 User 객체를 생성하고 필드값을 확인한다.")
+    @Test
+    void createUser() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("userId", "1");
+        params.put("password", "1234");
+        params.put("name", "name");
+        params.put("email", "abc@naver.com");
+
+        // when
+        User user = userHandler.createUser(params);
+
+        // then
+        assertThat(user.getUserId()).isEqualTo("1");
+        assertThat(user.getPassword()).isEqualTo("1234");
+        assertThat(user.getName()).isEqualTo("name");
+        assertThat(user.getEmail()).isEqualTo("abc@naver.com");
+    }
+}

--- a/src/test/util/HttpRequestObjectTest.java
+++ b/src/test/util/HttpRequestObjectTest.java
@@ -3,11 +3,11 @@ package util;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpRequestObjectTest {
 
-    @DisplayName("from 정적 팩토리 메서드로 RequestLine을 파싱 후 HttpRequestObject를 생성한다.")
+    @DisplayName("단순한 RequestLine을 파싱 후 HttpRequestObject를 생성한다.")
     @Test
     void from() {
         // given
@@ -17,8 +17,27 @@ class HttpRequestObjectTest {
         HttpRequestObject httpRequestObject = HttpRequestObject.from(requestLine);
 
         // then
-        assertEquals("GET", httpRequestObject.getRequestMethod());
-        assertEquals("/index.html", httpRequestObject.getRequestPath());
-        assertEquals("HTTP/1.1", httpRequestObject.getHttpVersion());
+        assertThat(httpRequestObject.getRequestMethod()).isEqualTo("GET");
+        assertThat(httpRequestObject.getRequestPath()).isEqualTo("/index.html");
+        assertThat(httpRequestObject.getHttpVersion()).isEqualTo("HTTP/1.1");
+    }
+
+    @DisplayName("requestParam이 존재하는 RequestLine을 파싱 후 HttpRequestObject를 생성한다.")
+    @Test
+    void fromWithParams() {
+        // given
+        String requestLine = "GET /user/create?userId=userId&password=password&name=name&email=abc@naver.com HTTP/1.1";
+
+        // when
+        HttpRequestObject httpRequestObject = HttpRequestObject.from(requestLine);
+
+        // then
+        assertThat(httpRequestObject.getRequestMethod()).isEqualTo("GET");
+        assertThat(httpRequestObject.getRequestPath()).isEqualTo("/user/create");
+        assertThat(httpRequestObject.getHttpVersion()).isEqualTo("HTTP/1.1");
+        assertThat(httpRequestObject.getRequestParams().get("userId")).isEqualTo("userId");
+        assertThat(httpRequestObject.getRequestParams().get("password")).isEqualTo("password");
+        assertThat(httpRequestObject.getRequestParams().get("name")).isEqualTo("name");
+        assertThat(httpRequestObject.getRequestParams().get("email")).isEqualTo("abc@naver.com");
     }
 }

--- a/src/test/util/HttpRequestObjectTest.java
+++ b/src/test/util/HttpRequestObjectTest.java
@@ -1,0 +1,24 @@
+package util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpRequestObjectTest {
+
+    @DisplayName("from 정적 팩토리 메서드로 RequestLine을 파싱 후 HttpRequestObject를 생성한다.")
+    @Test
+    void from() {
+        // given
+        String requestLine = "GET /index.html HTTP/1.1";
+
+        // when
+        HttpRequestObject httpRequestObject = HttpRequestObject.from(requestLine);
+
+        // then
+        assertEquals("GET", httpRequestObject.getRequestMethod());
+        assertEquals("/index.html", httpRequestObject.getRequestURI());
+        assertEquals("HTTP/1.1", httpRequestObject.getHttpVersion());
+    }
+}

--- a/src/test/util/HttpRequestObjectTest.java
+++ b/src/test/util/HttpRequestObjectTest.java
@@ -18,7 +18,7 @@ class HttpRequestObjectTest {
 
         // then
         assertEquals("GET", httpRequestObject.getRequestMethod());
-        assertEquals("/index.html", httpRequestObject.getRequestURI());
+        assertEquals("/index.html", httpRequestObject.getRequestPath());
         assertEquals("HTTP/1.1", httpRequestObject.getHttpVersion());
     }
 }

--- a/src/test/util/HttpRequestParserTest.java
+++ b/src/test/util/HttpRequestParserTest.java
@@ -9,7 +9,7 @@ class HttpRequestParserTest {
 
     String line = "GET /index.html HTTP/1.1";
 
-    @DisplayName("RequestLine")
+    @DisplayName("RequestLine을 파싱하여 총 3가지 요소를 반환한다.")
     @Test
     void parseRequestLine() {
         // when
@@ -21,7 +21,7 @@ class HttpRequestParserTest {
         assertEquals("HTTP/1.1", requestLine[2]);
     }
 
-    @DisplayName("RequestMethod")
+    @DisplayName("RequestLine을 파싱하여 RequestMethod만을 반환한다.")
     @Test
     void parseRequestMethod() {
         // when
@@ -31,7 +31,7 @@ class HttpRequestParserTest {
         assertEquals("GET", requestMethod);
     }
 
-    @DisplayName("RequestURI")
+    @DisplayName("RequestLine을 파싱하여 RequestURI만을 반환한다.")
     @Test
     void parseRequestURI() {
         // when

--- a/src/test/util/HttpRequestParserTest.java
+++ b/src/test/util/HttpRequestParserTest.java
@@ -3,7 +3,7 @@ package util;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpRequestParserTest {
 
@@ -16,9 +16,7 @@ class HttpRequestParserTest {
         String[] requestLine = HttpRequestParser.parseRequestLine(line);
 
         // then
-        assertEquals("GET", requestLine[0]);
-        assertEquals("/index.html", requestLine[1]);
-        assertEquals("HTTP/1.1", requestLine[2]);
+        assertThat(requestLine).containsExactly("GET", "/index.html", "HTTP/1.1");
     }
 
     @DisplayName("RequestLine을 파싱하여 RequestMethod만을 반환한다.")
@@ -28,7 +26,7 @@ class HttpRequestParserTest {
         String requestMethod = HttpRequestParser.parseRequestMethod(line);
 
         // then
-        assertEquals("GET", requestMethod);
+        assertThat(requestMethod).isEqualTo("GET");
     }
 
     @DisplayName("RequestLine을 파싱하여 RequestURI만을 반환한다.")
@@ -38,6 +36,6 @@ class HttpRequestParserTest {
         String requestURI = HttpRequestParser.parseRequestURI(line);
 
         // then
-        assertEquals("/index.html", requestURI);
+        assertThat(requestURI).isEqualTo("/index.html");
     }
 }


### PR DESCRIPTION
# 웹서버 만들기 1주차 3단계: GET으로 회원가입
- [x] 기존 HttpRequestObject 객체 재사용성을 고려한 개편
- [x] 단순 정적 파일 요청인지, 실제 비즈니스 로직인지 판정하는 과정 RequestHandler에 추가
- [x] 싱글톤 패턴 기반 요청을 1차적으로 처리하는 RequestProcess, DB에 접근하는 Handler 객체 생성
- [x] 회원가입 버튼 누를 시 메인 화면으로 넘어가는 리다이렉트 기능 구현
- [x] 테스트코드 작성 및 AssertJ 라이브러리로 교체
- [ ] 핵심 객체 추상화 및 구조 개선
- [ ] [학습 내용 Github Wiki에 기록](https://github.com/win-luck/be-was-2024/wiki)

# 의문점
<img width="1196" alt="image" src="https://github.com/softeerbootcamp4th/be-was-2024/assets/53044069/b3cf9709-9e7d-43f9-9ea0-d807f829c9a4">

* 과제3의 주요 요구사항 충족 후 회원가입 버튼을 누르면 메인화면으로 돌아오는 리다이렉트 기능을 구현하고자 하나, /user/create 회원가입 요청 후 클라이언트로부터 들어오는 모든 자원 요청의 URI 맨 앞에 prefix로 "/user"가 붙고 있음
* 따라서 실제 정적 파일 탐색이 실패하여 css/svg 등의 파일을 불러오지 못하고 있음
* 메인화면의 index.html의 모든 이미지 파일 경로 앞의 .을 제거하여 절대경로로 만들면 문제가 없으나, 더 바람직한 해결 방안 조사 중

-> 현재 302 Rediect 기능을 통해 처리 완료