### PR TITLE
week1 과제 1~3 마무리 PR

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="true">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="false" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/src/main/java/common/JsonBuilder.java
+++ b/src/main/java/common/JsonBuilder.java
@@ -1,0 +1,24 @@
+package common;
+
+import model.User;
+
+import java.util.Collection;
+
+public class JsonBuilder {
+
+    public static String buildJsonResponse(Collection<User> users) {
+        StringBuilder jsonResponse = new StringBuilder("[");
+        for (User user : users) {
+            jsonResponse.append("{")
+                    .append("\"userId\":\"").append(user.getUserId()).append("\",")
+                    .append("\"name\":\"").append(user.getName()).append("\",")
+                    .append("\"password\":\"").append(user.getPassword()).append("\"")
+                    .append("},");
+        }
+        if (jsonResponse.length() > 1) {
+            jsonResponse.setLength(jsonResponse.length() - 1); // 마지막 쉼표 제거
+        }
+        jsonResponse.append("]");
+        return jsonResponse.toString();
+    }
+}

--- a/src/main/java/common/WebUtils.java
+++ b/src/main/java/common/WebUtils.java
@@ -2,8 +2,8 @@ package common;
 
 public class WebUtils {
 
-    public static boolean isMethodHeader(String keyword) {
-        return keyword.equals("GET") || keyword.equals("POST") || keyword.equals("PUT") || keyword.equals("PATCH") || keyword.equals("DELETE");
+    public static boolean isMethodHeader(String method) {
+        return method.equals("GET") || method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE");
     }
 
     public static String getProperContentType(String extension) {
@@ -17,5 +17,9 @@ public class WebUtils {
             case "svg" -> "image/svg+xml";
             default -> null;
         };
+    }
+
+    public static boolean isRESTRequest(String path) {
+        return path.split("\\.").length==1;
     }
 }

--- a/src/main/java/common/WebUtils.java
+++ b/src/main/java/common/WebUtils.java
@@ -1,5 +1,8 @@
 package common;
 
+/**
+ * Web 요청을 처리할 때 공통으로 사용할 로직을 정리한 유틸리티 클래스
+ */
 public class WebUtils {
 
     public static boolean isMethodHeader(String method) {

--- a/src/main/java/common/WebUtils.java
+++ b/src/main/java/common/WebUtils.java
@@ -6,6 +6,14 @@ public class WebUtils {
         return method.equals("GET") || method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE");
     }
 
+    public static boolean isGetRequest(String method) {
+        return method.equals("GET");
+    }
+
+    public static boolean isPostRequest(String method) {
+        return method.equals("POST");
+    }
+
     public static String getProperContentType(String extension) {
         return switch (extension) {
             case "html" -> "text/html";

--- a/src/main/java/common/WebUtils.java
+++ b/src/main/java/common/WebUtils.java
@@ -23,7 +23,7 @@ public class WebUtils {
             case "png" -> "image/png";
             case "jpg" -> "image/jpeg";
             case "svg" -> "image/svg+xml";
-            default -> null;
+            default -> "*/*";
         };
     }
 

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -20,4 +20,8 @@ public class Database {
     public static Collection<User> findAll() {
         return users.values();
     }
+
+    public static void initialize() {
+        users = new HashMap<>();
+    }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -4,12 +4,14 @@ import java.io.*;
 import java.net.Socket;
 
 import common.WebUtils;
+import db.Database;
+import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-    private final String dirPath = "/Users/eckrin/study/be-was-2024/src/main/resources/static";
+    private final String dirPath = "./src/main/resources/static";
 
     private Socket connection;
     private WebAdapter webAdapter;
@@ -26,14 +28,33 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             String str, path = "", extension = "", contentType = "";
+            System.out.println();
+            System.out.println("====REQUEST====");
 
             while(!(str = br.readLine()).isEmpty()) {
                 String[] headerLine = str.split(" ");
                 if(WebUtils.isMethodHeader(headerLine[0])) { // request uri path 추출하기
                     path = headerLine[1];
+                    System.out.println("@@path = " + path);
                     if(WebUtils.isRESTRequest(path)) {
-                        path = webAdapter.resolveRequestUri(path);
-                        System.out.println("path = " + path);
+                        // 실습을 위한 GET방식 회원가입
+                        if(path.split("\\?")[0].equals("/user/create")) {
+                            String userId = path.split("\\?")[1].split("&")[0].split("=")[1];
+                            String nickname = path.split("\\?")[1].split("&")[1].split("=")[1];
+                            String password = path.split("\\?")[1].split("&")[2].split("=")[1];
+                            Database.addUser(new User(userId, password, nickname, null));
+
+                            String redirectResponse = "HTTP/1.1 302 Found\r\n" +
+                                    "Location: /\r\n" +
+                                    "Content-Length: 0\r\n" +
+                                    "\r\n";
+                            out.write(redirectResponse.getBytes());
+                        }
+                        // 일반적인 GET Request
+                        else if(WebUtils.isGetRequest(headerLine[0])) {
+                            System.out.println("path = " + path);
+                            path = webAdapter.resolveRequestUri(path);
+                        }
                     }
                     extension = path.substring(path.lastIndexOf(".")+1);
                     contentType = WebUtils.getProperContentType(extension);
@@ -49,6 +70,7 @@ public class RequestHandler implements Runnable {
 
     private void readAndResponseFromPath(OutputStream out, String path, String contentType) throws IOException{
         DataOutputStream dos = new DataOutputStream(out);
+        System.out.println("path = " + path);
         File file = new File(path);
         byte[] body = new byte[(int)file.length()];
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -12,9 +12,11 @@ public class RequestHandler implements Runnable {
     private final String dirPath = "/Users/eckrin/study/be-was-2024/src/main/resources/static";
 
     private Socket connection;
+    private WebAdapter webAdapter;
 
-    public RequestHandler(Socket connectionSocket) {
+    public RequestHandler(Socket connectionSocket, WebAdapter adapter) {
         this.connection = connectionSocket;
+        this.webAdapter = adapter;
     }
 
     @Override
@@ -29,26 +31,33 @@ public class RequestHandler implements Runnable {
                 String[] headerLine = str.split(" ");
                 if(WebUtils.isMethodHeader(headerLine[0])) { // request uri path 추출하기
                     path = headerLine[1];
+                    if(WebUtils.isRESTRequest(path)) {
+                        path = webAdapter.resolveRequestUri(path);
+                        System.out.println("path = " + path);
+                    }
                     extension = path.substring(path.lastIndexOf(".")+1);
                     contentType = WebUtils.getProperContentType(extension);
+                    readAndResponseFromPath(out, dirPath+path, contentType);
                 }
                 logger.debug("{}", str);
             }
 
-            // read file
-            DataOutputStream dos = new DataOutputStream(out);
-            File file = new File(dirPath + path);
-            byte[] body = new byte[(int)file.length()];
-
-            try(FileInputStream fis = new FileInputStream(file)) {
-                fis.read(body);
-            }
-
-            response200Header(dos, body.length, contentType);
-            responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private void readAndResponseFromPath(OutputStream out, String path, String contentType) throws IOException{
+        DataOutputStream dos = new DataOutputStream(out);
+        File file = new File(path);
+        byte[] body = new byte[(int)file.length()];
+
+        try(FileInputStream fis = new FileInputStream(file)) {
+            fis.read(body);
+        }
+
+        response200Header(dos, body.length, contentType);
+        responseBody(dos, body);
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -31,14 +31,16 @@ public class RequestHandler implements Runnable {
             while(!(str = br.readLine()).isEmpty()) {
                 logger.debug("{}", str);
                 String[] headerLine = str.split(" ");
-                if(WebUtils.isMethodHeader(headerLine[0])) { // request method 헤더에서
+                if(WebUtils.isMethodHeader(headerLine[0])) { // request method 헤더에 request uri path가 존재하므로
                     path = headerLine[1]; // request uri path 추출하기
+                    // rest요청일 경우 - 적절한 view를 찾거나, 적절한 비즈니스 로직 수행
                     if(WebUtils.isRESTRequest(path)) {
-                        // GET Request
+                        // GET 요청일 경우
                         if(WebUtils.isGetRequest(headerLine[0])) {
                             path = webAdapter.resolveRequestUri(path, out);
                         }
                     }
+                    // 설정한 path를 바탕으로 확장자에 맞게 contentType에 맞게 뷰 파일을 찾아 응답
                     extension = path.substring(path.lastIndexOf(".")+1);
                     contentType = WebUtils.getProperContentType(extension);
                     readAndResponseFromPath(out, dirPath+path, contentType);
@@ -50,6 +52,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
+    /**
+     * 경로에서 적절한 뷰 파일을 찾아서 응답합니다.
+     */
     private void readAndResponseFromPath(OutputStream out, String path, String contentType) throws IOException{
         DataOutputStream dos = new DataOutputStream(out);
         File file = new File(path);

--- a/src/main/java/webserver/WebAdapter.java
+++ b/src/main/java/webserver/WebAdapter.java
@@ -1,0 +1,15 @@
+package webserver;
+
+public class WebAdapter {
+
+    public String resolveRequestUri(String restUri) {
+        return switch(restUri) {
+            case "","/" -> "/index.html";
+            case "/login" -> "/login/index.html";
+            case "/registration" -> "/registration/index.html";
+            case "/comment" -> "/comment/index.html";
+            case "/article" -> "/article/index.html";
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/webserver/WebAdapter.java
+++ b/src/main/java/webserver/WebAdapter.java
@@ -16,7 +16,7 @@ public class WebAdapter {
     /**
      * handle specific requests
      */
-    public String resolveRequestUri(String restUri, OutputStream out) throws IOException {
+    public static String resolveRequestUri(String restUri, OutputStream out) throws IOException {
         // registration
         if(restUri.split("\\?")[0].equals("/user/create")) {
             String userId = restUri.split("\\?")[1].split("&")[0].split("=")[1];
@@ -62,7 +62,7 @@ public class WebAdapter {
     /**
      * map request uri to proper view
      */
-    private String resolveRequestUri(String restUri) {
+    private static String resolveRequestUri(String restUri) {
 
         return switch(restUri) {
             case "/login" -> "/login/index.html";

--- a/src/main/java/webserver/WebAdapter.java
+++ b/src/main/java/webserver/WebAdapter.java
@@ -1,8 +1,63 @@
 package webserver;
 
-public class WebAdapter {
+import common.JsonBuilder;
+import db.Database;
+import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-    public String resolveRequestUri(String restUri) {
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+
+public class WebAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+
+    /**
+     * treat various request cases - especially registration form
+     */
+    public String resolveRequestUri(String restUri, OutputStream out) throws IOException {
+        if(restUri.split("\\?")[0].equals("/user/create")) {
+            String userId = restUri.split("\\?")[1].split("&")[0].split("=")[1];
+            String nickname = restUri.split("\\?")[1].split("&")[1].split("=")[1];
+            String password = restUri.split("\\?")[1].split("&")[2].split("=")[1];
+            Database.addUser(new User(userId, password, nickname, null));
+            logger.info("User Added - Database.findAll().size() = {}", Database.findAll().size());
+
+            String redirectResponse = "HTTP/1.1 302 Found\r\n" +
+                    "Location: /\r\n" +
+                    "Content-Length: 0\r\n" +
+                    "\r\n";
+            out.write(redirectResponse.getBytes());
+            return "/index.html";
+        } else if(restUri.split("\\?")[0].equals("/user/list")) {
+
+            Collection<User> users = Database.findAll();
+            String jsonUser = JsonBuilder.buildJsonResponse(users);
+
+            String response = "HTTP/1.1 200 OK\r\n" +
+                    "Content-Type: application/json\r\n" +
+                    "Content-Length: " + jsonUser.length() + "\r\n" +
+                    "\r\n" +
+                    jsonUser;
+            out.write(response.getBytes());
+            return "/index.html";
+        } else if(restUri.split("\\?")[0].equals("/database/init")) {
+            Database.initialize();
+
+            String response = "HTTP/1.1 200 OK\r\n";
+            out.write(response.getBytes());
+            return "/index.html";
+        } else {
+            return resolveRequestUri(restUri);
+        }
+    }
+
+    /**
+     * map request uri to proper view uri
+     */
+    private String resolveRequestUri(String restUri) {
+
         return switch(restUri) {
             case "/login" -> "/login/index.html";
             case "/registration" -> "/registration/index.html";

--- a/src/main/java/webserver/WebAdapter.java
+++ b/src/main/java/webserver/WebAdapter.java
@@ -14,9 +14,10 @@ public class WebAdapter {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     /**
-     * treat various request cases - especially registration form
+     * handle specific requests
      */
     public String resolveRequestUri(String restUri, OutputStream out) throws IOException {
+        // registration
         if(restUri.split("\\?")[0].equals("/user/create")) {
             String userId = restUri.split("\\?")[1].split("&")[0].split("=")[1];
             String nickname = restUri.split("\\?")[1].split("&")[1].split("=")[1];
@@ -30,7 +31,9 @@ public class WebAdapter {
                     "\r\n";
             out.write(redirectResponse.getBytes());
             return "/index.html";
-        } else if(restUri.split("\\?")[0].equals("/user/list")) {
+        }
+        // get user list
+        else if(restUri.split("\\?")[0].equals("/user/list")) {
 
             Collection<User> users = Database.findAll();
             String jsonUser = JsonBuilder.buildJsonResponse(users);
@@ -42,19 +45,22 @@ public class WebAdapter {
                     jsonUser;
             out.write(response.getBytes());
             return "/index.html";
-        } else if(restUri.split("\\?")[0].equals("/database/init")) {
+        }
+        // initialize database
+        else if(restUri.split("\\?")[0].equals("/database/init")) {
             Database.initialize();
 
             String response = "HTTP/1.1 200 OK\r\n";
             out.write(response.getBytes());
             return "/index.html";
-        } else {
-            return resolveRequestUri(restUri);
         }
+
+
+        return resolveRequestUri(restUri);
     }
 
     /**
-     * map request uri to proper view uri
+     * map request uri to proper view
      */
     private String resolveRequestUri(String restUri) {
 

--- a/src/main/java/webserver/WebAdapter.java
+++ b/src/main/java/webserver/WebAdapter.java
@@ -4,12 +4,11 @@ public class WebAdapter {
 
     public String resolveRequestUri(String restUri) {
         return switch(restUri) {
-            case "","/" -> "/index.html";
             case "/login" -> "/login/index.html";
             case "/registration" -> "/registration/index.html";
             case "/comment" -> "/comment/index.html";
             case "/article" -> "/article/index.html";
-            default -> null;
+            default -> "/index.html";
         };
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -3,8 +3,10 @@ package webserver;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +14,7 @@ import org.slf4j.LoggerFactory;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
-    private static final int THREAD_POOL_SIZE = 1; // 톰캣(Tomcat 9 기준)의 default max pool size는 200
+    private static final int THREAD_POOL_SIZE = 200; // 톰캣(Tomcat 9 기준)의 default max pool size는 200
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -30,13 +32,27 @@ public class WebServer {
 
             // 클라이언트가 연결될 때까지 대기한다.
             Socket connection;
+            RequestHandler requestHandler = RequestHandler.getInstance();
             while ((connection = listenSocket.accept()) != null) {
-                threadPool.execute(new RequestHandler(connection, new WebAdapter()));
+                setConnAndExecute(threadPool, connection, requestHandler);
             }
         } catch (IOException e) {
             logger.error("Server Start Error: " + e.getMessage());
         } finally {
             threadPool.shutdown();
+        }
+    }
+
+    // execute하기 전에 다른 스레드가 다른 connection을 주입하는 것을 방지하기 위해 동기화
+    private static synchronized void setConnAndExecute(ExecutorService threadPool, Socket connection, RequestHandler handler) {
+        logger.debug("connection = " + connection);
+        handler.setConnection(connection);
+
+        Future<?> future = threadPool.submit(handler);
+        try{
+            future.get();
+        } catch (ExecutionException | InterruptedException e) {
+            logger.error(e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -31,7 +31,7 @@ public class WebServer {
             // 클라이언트가 연결될 때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                threadPool.execute(new RequestHandler(connection));
+                threadPool.execute(new RequestHandler(connection, new WebAdapter()));
             }
         } catch (IOException e) {
             logger.error("Server Start Error: " + e.getMessage());

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
-    private static final int THREAD_POOL_SIZE = 200; // 톰캣(Tomcat 9 기준)의 default max pool size는 200
+    private static final int THREAD_POOL_SIZE = 1; // 톰캣(Tomcat 9 기준)의 default max pool size는 200
 
     public static void main(String args[]) throws Exception {
         int port = 0;

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="../reset.css" rel="stylesheet" />
     <link href="../global.css" rel="stylesheet" />
+    <script>
+        function sendRequest() {
+            const form = document.getElementById('dataForm');
+
+            const url = new URL('/user/create', window.location.origin);
+            const params = new URLSearchParams(new FormData(form));
+
+            window.location.href = url+'?'+params.toString();
+        }
+    </script>
   </head>
   <body>
     <div class="container">
@@ -23,30 +33,39 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form class="form" id="dataForm">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
+            <label for="userId"></label>
             <input
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
+              id="userId"
+              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
             <p class="title_textfield">닉네임</p>
+              <label for="name"></label>
             <input
               class="input_textfield"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
+              id="name"
+              name="name"
             />
           </div>
           <div class="textfield textfield_size_s">
             <p class="title_textfield">비밀번호</p>
+              <label for="password"></label>
             <input
               class="input_textfield"
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
+              id="password"
+              name="password"
             />
           </div>
           <button
@@ -54,6 +73,7 @@
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
             type="button"
+            onclick="sendRequest()"
           >
             회원가입
           </button>

--- a/src/test/java/user/RegistrationIntegrationTest.java
+++ b/src/test/java/user/RegistrationIntegrationTest.java
@@ -1,0 +1,107 @@
+package user;
+
+import model.User;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import user.common.UserJsonBuilder;
+import webserver.RequestHandler;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class RegistrationIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    HttpURLConnection connection;
+
+    @BeforeEach
+    public void setUp() throws Exception{
+        // 실제 서버에 데이터베이스 초기화 요청
+        URL registerUrl = new URL("http://localhost:8080/database/init");
+        connection = (HttpURLConnection) registerUrl.openConnection();
+        connection.setRequestMethod("GET");
+        System.out.println("******** DATABASE INITIALIZED ********");
+    }
+
+    /**
+     * Mock서버를 사용 불가능하므로 실제 서버를 열어놓고 요청을 보낸다.
+     * 테스트 서버와 실제 서버의 Database 객체가 상이하므로 실제 서버에 api 요청을 통해서 실제 서버의 Database를 조회하여 검증하였다.
+     */
+    @Test
+    @DisplayName("유저 회원가입 테스트 (성공 case)")
+    public void userRegistrationTestSuccess() throws Exception {
+        // 1. 실제 서버에 회원가입 요청
+        URL registerUrl = new URL("http://localhost:8080/user/create?userId=testid&name=testname&password=testpassword");
+        connection = (HttpURLConnection) registerUrl.openConnection();
+        connection.setRequestMethod("GET");
+        Assertions.assertEquals(200, connection.getResponseCode());
+
+        // 2. 실제 서버의 User DB 조회
+        URL getUserUrl = new URL("http://localhost:8080/user/list");
+        connection = (HttpURLConnection) getUserUrl.openConnection();
+        connection.setRequestMethod("GET");
+        Assertions.assertEquals(200, connection.getResponseCode());
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+
+        String responseLine;
+        StringBuilder responseContent = new StringBuilder();
+        while ((responseLine = in.readLine()) != null) {
+            responseContent.append(responseLine);
+        }
+        String response = responseContent.toString();
+        System.out.println("response = " + response);
+
+        // 3. 조회 결과 파싱
+        User[] users = UserJsonBuilder.parseJsonToUsers(response);
+        Assertions.assertEquals(users.length, 1);
+
+        connection.disconnect();
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 테스트 (실패 - 중복 회원 Id)")
+    public void userRegistrationTestFailOnDuplicate() throws Exception {
+        // 1. 실제 서버에 회원가입 요청
+        URL registerUrl1 = new URL("http://localhost:8080/user/create?userId=testid1&name=testname1&password=testpassword1");
+        connection = (HttpURLConnection) registerUrl1.openConnection();
+        connection.setRequestMethod("GET");
+        Assertions.assertEquals(200, connection.getResponseCode());
+
+        URL registerUrl2 = new URL("http://localhost:8080/user/create?userId=testid1&name=testname2&password=testpassword2");
+        connection = (HttpURLConnection) registerUrl2.openConnection();
+        connection.setRequestMethod("GET");
+        Assertions.assertEquals(200, connection.getResponseCode());
+
+        // 2. 실제 서버의 User DB 조회
+        URL getUserUrl = new URL("http://localhost:8080/user/list");
+        connection = (HttpURLConnection) getUserUrl.openConnection();
+        connection.setRequestMethod("GET");
+        Assertions.assertEquals(200, connection.getResponseCode());
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+
+        String responseLine;
+        StringBuilder responseContent = new StringBuilder();
+        while ((responseLine = in.readLine()) != null) {
+            responseContent.append(responseLine);
+        }
+
+        String response = responseContent.toString();
+        System.out.println("response = " + response);
+
+        // 3. 조회 결과 파싱
+        User[] users = UserJsonBuilder.parseJsonToUsers(response);
+        for (User user : users) {
+            System.out.println(user.getUserId());
+        }
+
+        Assertions.assertEquals(users.length, 1);
+        Assertions.assertNotEquals(users.length, 2);
+
+        connection.disconnect();
+    }
+}

--- a/src/test/java/user/RegistrationIntegrationTest.java
+++ b/src/test/java/user/RegistrationIntegrationTest.java
@@ -12,6 +12,9 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+/**
+ * 명세의 단위 테스트와는 거리가 먼 통합 테스트
+ */
 public class RegistrationIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);

--- a/src/test/java/user/RegistrationTest.java
+++ b/src/test/java/user/RegistrationTest.java
@@ -1,0 +1,47 @@
+package user;
+
+import db.Database;
+import model.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class RegistrationTest {
+
+    @BeforeEach
+    void setUp() {
+        Database.initialize();
+    }
+
+    @Test
+    @DisplayName("유저 저장 테스트 (성공 case)")
+    public void userRegistrationTestSuccess() throws Exception {
+        // when
+        Database.addUser(new User("testId1", "testPwd1", "testName1", "testEmail1"));
+        Database.addUser(new User("testId2", "testPwd2", "testName2", "testEmail2"));
+        Database.addUser(new User("testId3", "testPwd3", "testName3", "testEmail3"));
+
+        // then
+        Assertions.assertEquals(Database.findAll().size(), 3);
+        Assertions.assertEquals(Database.findUserById("testId1").getPassword(), "testPwd1");
+        Assertions.assertEquals(Database.findUserById("testId1").getName(), "testName1");
+        Assertions.assertEquals(Database.findUserById("testId1").getEmail(), "testEmail1");
+    }
+
+    @Test
+    @DisplayName("유저 저장 테스트 (실패 - 중복 회원 Id)")
+    public void userRegistrationTestFailOnDuplicate() throws Exception {
+        // when
+        Database.addUser(new User("testId1", "testPwd1", "testName1", "testEmail1"));
+        Database.addUser(new User("testId1", "testPwd2", "testName2", "testEmail2"));
+
+        // then
+        Assertions.assertEquals(Database.findAll().size(), 1);
+        Assertions.assertNotEquals(Database.findAll().size(), 2);
+        // 현재 Database 저장 로직상 나중에 들어간 회원이 저장된다.
+        Assertions.assertEquals(Database.findUserById("testId1").getPassword(), "testPwd2");
+        Assertions.assertEquals(Database.findUserById("testId1").getName(), "testName2");
+        Assertions.assertEquals(Database.findUserById("testId1").getEmail(), "testEmail2");
+    }
+}

--- a/src/test/java/user/common/UserJsonBuilder.java
+++ b/src/test/java/user/common/UserJsonBuilder.java
@@ -1,0 +1,52 @@
+package user.common;
+
+import model.User;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserJsonBuilder {
+
+    public static User[] parseJsonToUsers(String response) {
+        // JSON 부분만 추출
+        String jsonResponse = extractJson(response);
+
+        // JSON을 User 배열로 변환
+        User[] users = parseJsonToUserArray(jsonResponse);
+
+        return users;
+    }
+
+    private static String extractJson(String response) {
+        // "HTTP/1.1" 이전의 JSON 부분 추출
+        int index = response.indexOf("[");
+        return response.substring(index, response.indexOf("]") + 1);
+    }
+
+    private static User[] parseJsonToUserArray(String jsonResponse) {
+        List<User> userList = new ArrayList<>();
+
+        // JSON 배열 문자열을 파싱
+        String[] jsonObjects = jsonResponse.substring(1, jsonResponse.length() - 1).split("\\},\\{");
+        for (String jsonObject : jsonObjects) {
+            jsonObject = jsonObject.replace("{", "").replace("}", "").replace("\"", "");
+            String[] fields = jsonObject.split(",");
+            String userId = null, name = null, password = null;
+
+            for (String field : fields) {
+                String[] keyValue = field.split(":");
+                if (keyValue[0].trim().equals("userId")) {
+                    userId = keyValue[1].trim();
+                } else if (keyValue[0].trim().equals("name")) {
+                    name = keyValue[1].trim();
+                } else if (keyValue[0].trim().equals("password")) {
+                    password = keyValue[1].trim();
+                }
+            }
+
+            // email은 JSON에 없으므로 null로 설정
+            userList.add(new User(userId, password, name, null));
+        }
+
+        return userList.toArray(new User[0]);
+    }
+}


### PR DESCRIPTION
**1.**
과제 명세를 잘못 이해해서 단위 테스트가 아닌, 통합 테스트를 먼저 진행했습니다.
잘못 진행한 테스트는 별도의 클래스 (test/user/RegistrationIntegrationTest.java)에 남겨놓고, 요구 명세대로의 테스트 코드는 test/user/RegistrationTest.java에 추가로 작성하였습니다.

[알게 된 지식]
- main application과 test 환경에서 Database의 static 멤버(users)가 별도 객체로 존재하는 것으로 보아(참조값이 다릅니다), 각각 다른 JVM에서 동작하거나 별도 스레드에서 동작한다는 것을 예측할 수 있었습니다. (제 예측은 - JVM의 Runtime Data 영역에서 static 객체가 할당되는 Method 영역은 스레드간 공유가 이루어집니다. 따라서 둘은 별도의 JVM을 이용하여 실행되는 것으로 추측되는데, 아니라면 피드백 부탁드립니다)
- 스프링부트 사용시, 빈을 싱글톤으로 유지시켜주는 스프링 컨테이너(ApplicationContext)를 통해서 테스트 환경에서도 동일한 객체를 주입받을 수 있는 것으로 추측됩니다. 

</br>

**2.**
과제 2의 WebServer 클래스에서 ExecutorService를 사용할 때, 톰캣의 default max pool size와 동일하게 스레드 풀 사이즈를 200으로 설정했습니다. 하지만 그렇게 할 경우 헤더를 출력하는 debug log가 뒤섞이는 문제점을 발견했습니다.

[THREAD_POOL_SIZE = 200]
![Pasted Graphic](https://github.com/softeerbootcamp4th/be-was-2024/assets/81168401/853eb71e-a746-4599-a442-d4ca603118af)


[THREAD_POOL_SIZE = 1]
![Pasted Graphic 1](https://github.com/softeerbootcamp4th/be-was-2024/assets/81168401/8386857e-d9de-44ad-a6e7-03d56bed7ce1)

따라서 멀티스레드 환경에서 로그 순서를 보장할 수 있도록 다음과 같은 해결책에 대해서 고민해 보았습니다.

**2-1. THREAD_POOL_SIZE를 1로 고정하여 단일 쓰레드 환경에서 동작하도록 합니다.**

**2-2. StringBuilder를 이용하여 로그를 한번에 출력하도록 합니다.**
 Logback은 thread-safety를 보장하므로(https://logback.qos.ch/manual/architecture.html) 문제가 발생하지 않을 것으로 추측됩니다. 
-> 하지만 문제는 하나의 run() 안에 Logback 메서드가 두 개 이상 존재한다면 여전히 동시성 문제가 발생하므로, 로그를 무조건 한 번에 출력해야 한다는 문제가 여전히 존재합니다.

**2-3. 메서드 단위 동기화를 적용합니다.**
-> synchronized는 하나의 객체의 메서드에 여러 스레드가 접근시에 동시성 문제가 발생하지 않도록 하므로, 스레드마다 RequestHandler 객체를 생성하는 현재 코드에서는 동작하지 않습니다.
-> 각 클라이언트 요청이 별도의 Socket을 가져야 하므로, RequestHandler를 싱글톤으로 관리하고, 요청마다 달라지는 Socket 객체의 경우 setter를 이용한 필드 주입을 통해서 스레드마다 별도의 소켓 객체를 주입해 주었습니다.


<img width="1053" alt="Pasted Graphic" src="https://github.com/softeerbootcamp4th/be-was-2024/assets/81168401/d8541caf-cf39-41d3-bca1-81a3e323c249">
하지만 이렇게 이미 소켓이 닫혔다는 에러가 뜨면서 종료되어버리는 쓰레드가 존재합니다.
</br></br>
이 현상의 가장 큰 원인은 ExecutorService의 execute() 메서드가 비동기 방식으로 동작하기 때문이었습니다. ExecutorService를 통해서 실행된 run() 메서드가 정상적으로 종료되기도 전에 다음 작업이 넘어오면서 RequestHandler의 socket객체를 초기화해버리는 경우 기존 소켓이 닫혀 사용할 수 없는 것으로 보입니다. 

<img width="955" alt="image" src="https://github.com/softeerbootcamp4th/be-was-2024/assets/81168401/c602e0cb-6005-4823-a08f-2603d14c04cc">
따라서 위와 같이 Future 객체를 이용하여 비동기 요청의 콜백을 받은 후에 다음 요청을 보내도록 현재 스레드를 블로킹하여 문제를 해결했습니다.

[결과]
<img width="984" alt="image" src="https://github.com/softeerbootcamp4th/be-was-2024/assets/81168401/6f2d3080-6440-4b73-aeea-c8f0741cc2f1">
정상적으로 쓰레드별 로그가 출력되는 것을 확인할 수 있었습니다.

</br>

물론 로깅을 위해서 기존 핵심 로직의 변경을 초래하는 현재의 방식이 옳지 않음은 인지하고 있습니다. 다만 비동기, 동시성 문제와 관련된 라이브러리를 활용하고, 동시성 문제들이 발생 가능한 포인트를 찾아보면서 공부를 하는 것에 중점을 두었습니다.




</br></br>
**[Week 1 과제를 진행하며 느낀 점, 배운 점]**

지금까지 스프링 환경에서만 서버 구축 및 테스트 코드를 작성해 보았는데, 순수 자바 환경에서의 테스트 코드를 작성해보며 아래와 같은 사실을 알게 되었습니다.

- 스프링의 프론트 컨트롤러 패턴(https://eckrin.tistory.com/62) 과 구현체들이 제공하는 편리함을 다시 한번 느낄 수 있었습니다.
- MockMvc의 위대함을 느꼈습니다.
- 객체지향적인 코드를 작성하기 위한 고민을 하였습니다.
- synchronized, Future, CountdownLatch 등에 대해서 공부, 사용해보며 동시성 문제가 발생 가능한 포인트들을 찾고, 해결해볼 수 있었습니다.
