### PR TITLE
[week1-2] 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,104 @@ BufferedInputStream bis = new BufferedInputStream(fis);
 bis.transferTo(bos);
 byte[] body = bos.toByteArray();
 ```
+## 2. 다양한 MimeType 지원하기
+
+### 확장자에서 MimeType으로 변환
+
+1. 우선 경로에서 파일 확장자를 분리한다.
+
+```java
+public class PathParser {
+    public String fileExtExtract(String fileName) {
+        int pointPos = fileName.lastIndexOf(".");
+        if(pointPos == -1) {
+           throw new IllegalArgumentException("파일 확장자가 존재하지 않는 파일 이름입니다.");
+        }
+        return fileName.substring(pointPos);
+    }
+}
+```
+
+1. HashMap을 이용하여 파일 이름과 MimeType을 매핑하였다.
+
+```java
+public class MimeTypeMapper {
+    private Map<String, MimeType> mimeTypeMapper;
+
+    public MimeTypeMapper() {
+        mimeTypeMapper = new HashMap<>() {{
+            put(".html", MimeType.HTML);
+            put(".css", MimeType.CSS);
+            put(".js", MimeType.JAVASCRIPT);
+            put(".svg", MimeType.SVG);
+            put(".ico", MimeType.ICO);
+            put(".png", MimeType.PNG);
+            put(".jpg", MimeType.JPG);
+        }};
+    }
+
+    public MimeType getMimeType(String ext) {
+        if(mimeTypeMapper.containsKey(ext)) {
+            return mimeTypeMapper.get(ext);
+        }
+        throw new IllegalArgumentException("확장자와 매핑되는 mimeType이 없습니다.");
+    }
+}
+```
+
+1. response의 `content-type` 헤더에 MimeType을 작성해주었다.
+
+```java
+dos.writeBytes("Content-Type: " + mimeType + "\r\n");
+```
+
+- 구현 방법
+    1. Enum을 이용하여 구현하기
+        - MimeType을 원시 값으로 나두는 것이 아니라 변수로 가질 수 있어 가독성이 좋다.
+        - 모든 MimeType을 순회해야 된다는 단점이 있음
+    2. HashMap을 이용하여 구현하기
+        - 해싱을 하는 비용이 발생할 수 있음
+    3. switch문을 이용하여 구현하기
+        - 지원하는 `Content-Type` 이 늘어난다면 코드가 너무 길어질 가능성이 존재
+
+### MimeType
+
+- 미디어 타입이란 문서, 파일 또는 바이트 집합의 성격과 형식
+- `type/subtype` 처럼 슬래시로 구분된 두 부분으로 구성됩니다.
+    - type: 데이터 타입이 속하는 일반 카테고리
+    - subtype: 정확한 종류의 데이터
+- `type/subtype;parameter=value` 처럼 매개변수를 추가할 수 있습니다.
+    - `charset` : 문자에 사용되는 문자 세트
+    - `q` : client가 선호하는 mimeType의 우선순위
+
+### Accept Header
+
+- 클라이언트가 이해 가능한 컨텐츠 타입이 무엇인지를 알려줍니다.
+- 콘텐츠 협상을 통해, 서버는 제안 중 하나를 선택하고 사용하며 `Content-Type` 응답 헤더로 클라이언트에게 선택된 타입을 알려줍니다.
+    - 콘텐츠 협상
+        - 클라이언트에게 적합한 자원을 제공하는 것
+        - 클라이언트와 함께 서로의 입장 차이를 줄여나가며 거래할 자원을 결정한다.
+
+### Content-Type
+
+- 리소스의 media type을 나타내기 위해 사용됩니다.
+- 반환된 컨텐츠의 컨텐츠 유형이 실제로 무엇인지를 알려줍니다.
+
+### Enum Map vs Hash Map
+
+- HashMap
+    - 해싱을 하는 과정이 있으므로 추가적인 연산이 존재
+    - 해시 충돌이 일어나는 과정에서 성능이 저하할 수 있다.
+- EnumMap
+    - 내부적으로 Array를 사용함.
+        - enum을 선언한 순서대로 저장
+        - oridinal()을 이용하여 순서를 반환 받을 수 있다.
+    - get 함수
+        - 배열을 통해 직접적으로 접근할 수 있다.
+    
+    ```java
+        public V get(Object key) {
+            return (isValidKey(key) ?
+                    unmaskNull(vals[((Enum)key).ordinal()]) : null);
+        }
+    ```

--- a/src/main/java/webserver/HttpRequestParser.java
+++ b/src/main/java/webserver/HttpRequestParser.java
@@ -1,0 +1,57 @@
+package webserver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class HttpRequestParser {
+
+    public Request getRequest(InputStream rawHttpRequest) throws IOException {
+        Request request = new Request();
+        BufferedReader br = new BufferedReader(new InputStreamReader(rawHttpRequest));
+        requestLineParse(request, br.readLine());
+        requestHeaderParse(request, br);
+        return request;
+    }
+
+    private void requestHeaderParse(Request request, BufferedReader br) throws IOException {
+        String tmp;
+        Map<String, String> headers = new ConcurrentHashMap<>();
+        while((tmp = br.readLine()) != null && !tmp.isEmpty()) {
+            String[] headerKeyValue = tmp.split(": ");
+            if(headerKeyValue.length != 2) {
+               throw new IllegalStateException("유효하지 않은 Http Header 형식");
+            }
+            headers.put(headerKeyValue[0], headerKeyValue[1]);
+        }
+    }
+
+    private void requestLineParse(Request request, String requestLine) {
+        String[] requestLineSplit = requestLine.split(" ");
+        request.setMethod(requestLineSplit[0]);
+        pathParse(request, requestLineSplit[1]);
+        request.setHttpVersion(requestLineSplit[2]);
+    }
+
+    private void pathParse(Request request, String path) {
+        // api path 파싱
+        String[] pathSplit = path.split("\\?");
+        String apiPath = pathSplit[0];
+        request.setPath(apiPath);
+
+        if(pathSplit.length == 1) return;
+
+        Map<String, String> queryParameters = new ConcurrentHashMap<>();
+        String rawQueryParameter = pathSplit[1];
+        String[] rawQueryParameters = rawQueryParameter.split("\\&");
+        for(String queryParameter: rawQueryParameters) {
+            String[] queryKeyValue = queryParameter.split("\\=");
+            queryParameters.put(queryKeyValue[0], queryKeyValue[1]);
+        }
+        request.setParameters(queryParameters);
+    }
+
+}

--- a/src/main/java/webserver/MimeType.java
+++ b/src/main/java/webserver/MimeType.java
@@ -1,0 +1,27 @@
+package webserver;
+
+public enum MimeType {
+    HTML("text/html"),
+    CSS("text/css"),
+    JAVASCRIPT("text/javascript"),
+    ICO("image/vnd.microsoft.icon"),
+    PNG("image/png"),
+    JPG("image/jpeg"),
+    SVG("image/svg+xml");
+
+    private String mimeType;
+
+    MimeType(String mimeType) {
+       this.mimeType = mimeType;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+
+    @Override
+    public String toString() {
+        return getMimeType();
+    }
+}

--- a/src/main/java/webserver/MimeTypeMapper.java
+++ b/src/main/java/webserver/MimeTypeMapper.java
@@ -1,0 +1,27 @@
+package webserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MimeTypeMapper {
+    private Map<String, MimeType> mimeTypeMapper;
+
+    public MimeTypeMapper() {
+        mimeTypeMapper = new HashMap<>() {{
+            put(".html", MimeType.HTML);
+            put(".css", MimeType.CSS);
+            put(".js", MimeType.JAVASCRIPT);
+            put(".svg", MimeType.SVG);
+            put(".ico", MimeType.ICO);
+            put(".png", MimeType.PNG);
+            put(".jpg", MimeType.JPG);
+        }};
+    }
+
+    public MimeType getMimeType(String ext) {
+        if(mimeTypeMapper.containsKey(ext)) {
+            return mimeTypeMapper.get(ext);
+        }
+        throw new IllegalArgumentException("확장자와 매핑되는 mimeType이 없습니다.");
+    }
+}

--- a/src/main/java/webserver/PathParser.java
+++ b/src/main/java/webserver/PathParser.java
@@ -1,0 +1,13 @@
+package webserver;
+
+public class PathParser {
+
+    public String fileExtExtract(String fileName) {
+        int pointPos = fileName.lastIndexOf(".");
+        if(pointPos == -1) {
+           throw new IllegalArgumentException("파일 확장자가 존재하지 않는 파일 이름입니다.");
+        }
+        return fileName.substring(pointPos);
+    }
+
+}

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -15,37 +15,17 @@ public class Request{
     private String path;
     private String httpVersion;
     private Map<String, String> httpHeaders;
+    private Map<String, String> parameters;
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    public Request(BufferedReader br) throws IOException {
-        requestLineParse(br.readLine());
-        httpHeaders = new ConcurrentHashMap<>();
-        List<String> headerLines = new ArrayList<>();
-        String tmp;
-        while((tmp = br.readLine()) != null && !tmp.isEmpty()) {
-            headerLines.add(tmp);
-        }
-        requestHeaderParse(headerLines);
+    public Request() {}
+
+    public String getHeader(String HeaderKey) {
+        return httpHeaders.get(HeaderKey);
     }
 
-    public void requestHeaderParse(List<String> headerLines) throws IOException {
-        for(String headerLine: headerLines) {
-            logger.debug("header " + headerLine);
-            String[] headerkv = headerLine.split(": ");
-            httpHeaders.put(headerkv[0], headerkv[1]);
-        }
-    }
-
-    public void requestLineParse(String requestLine) throws IOException {
-        logger.debug("requestLine " + requestLine);
-        String[] s = requestLine.split(" ");
-        this.method = s[0];
-        this.path = s[1];
-        this.httpVersion = s[2];
-    }
-
-    public String getHeader(String HeaderName) {
-        return httpHeaders.get(HeaderName);
+    public String getParameter(String parameterKey) {
+        return parameters.get(parameterKey);
     }
 
     public String getMethod() {
@@ -58,5 +38,29 @@ public class Request{
 
     public String getHttpVersion() {
         return httpVersion;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public void setHttpVersion(String httpVersion) {
+        this.httpVersion = httpVersion;
+    }
+
+    public Map<String, String> getHttpHeaders() {
+        return httpHeaders;
+    }
+
+    public void setHttpHeaders(Map<String, String> httpHeaders) {
+        this.httpHeaders = httpHeaders;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -23,14 +23,14 @@ public class RequestHandler implements Callable<Void> {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
 
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
-            BufferedReader br = new BufferedReader(new InputStreamReader(in));
-            Request request = new Request(br);
             DataOutputStream dos = new DataOutputStream(out);
+            HttpRequestParser httpRequestParser = new HttpRequestParser();
+            Request request = httpRequestParser.getRequest(in);
 
             // 파일 반환
             byte[] body;
             try(
-                    FileInputStream fis = new FileInputStream(new File("src/main/resources/static" + request.getPath()));
+                    FileInputStream fis = new FileInputStream("src/main/resources/static" + request.getPath());
                     BufferedInputStream bis = new BufferedInputStream(fis);
                     ByteArrayOutputStream bos = new ByteArrayOutputStream();
                     ) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Callable<Void> {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private static final PathParser fileParser = new PathParser();
 
     private Socket connection;
 
@@ -20,18 +21,28 @@ public class RequestHandler implements Callable<Void> {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             Request request = new Request(br);
-            // 파일 반환
             DataOutputStream dos = new DataOutputStream(out);
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            FileInputStream fis = new FileInputStream("src/main/resources/static" + request.getPath());
-            BufferedInputStream bis = new BufferedInputStream(fis);
-            bis.transferTo(bos);
-            byte[] body = bos.toByteArray();
 
-            response200Header(dos, body.length);
+            // 파일 반환
+            byte[] body;
+            try(
+                    FileInputStream fis = new FileInputStream(new File("src/main/resources/static" + request.getPath()));
+                    BufferedInputStream bis = new BufferedInputStream(fis);
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    ) {
+                bis.transferTo(bos);
+                body = bos.toByteArray();
+            }
+
+            String fileExt = fileParser.fileExtExtract(request.getPath());
+            MimeTypeMapper mimeTypeMapper = new MimeTypeMapper();
+            MimeType mimeType = mimeTypeMapper.getMimeType(fileExt);
+
+            response200Header(dos, body.length, mimeType);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -39,10 +50,10 @@ public class RequestHandler implements Callable<Void> {
         return null;
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, MimeType mimeType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + mimeType + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,13 +23,14 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form action="/create" method="get" class="form">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
+              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -38,6 +39,7 @@
               class="input_textfield"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
+              name="name"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -47,13 +49,14 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
+              name="password"
             />
           </div>
           <button
             id="registration-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
+            type="submit"
           >
             회원가입
           </button>

--- a/src/test/java/webserver/MimeTypeMapperTest.java
+++ b/src/test/java/webserver/MimeTypeMapperTest.java
@@ -1,0 +1,29 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MimeTypeMapperTest {
+
+    @Test
+    @DisplayName("올바른 확장자가 들어왔을 때")
+    void mimeTypeMapperCorrectTest() {
+       MimeTypeMapper mimeTypeMapper = new MimeTypeMapper();
+       String ext = ".css";
+       MimeType mimeType = mimeTypeMapper.getMimeType(ext);
+       assertThat(mimeType).isEqualTo(MimeType.CSS);
+    }
+
+    @Test
+    @DisplayName("mimeType이 존재하지 않는 파일 확장자가 들어왔을 때")
+    void mimeTypeMapperIncorrectTest() {
+        MimeTypeMapper mimeTypeMapper = new MimeTypeMapper();
+        String ext = ".cpp";
+        assertThatThrownBy(() -> {
+            mimeTypeMapper.getMimeType(ext);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/webserver/MimeTypeTest.java
+++ b/src/test/java/webserver/MimeTypeTest.java
@@ -1,0 +1,11 @@
+package webserver;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MimeTypeTest {
+    @Test
+    void ordinalTest() {
+        Assertions.assertThat(MimeType.CSS.ordinal()).isEqualTo(1);
+    }
+}

--- a/src/test/java/webserver/PathParserTest.java
+++ b/src/test/java/webserver/PathParserTest.java
@@ -1,0 +1,29 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PathParserTest {
+
+    static PathParser fileParser = new PathParser();
+
+    @Test
+    @DisplayName("파일 이름이 정상적으로 들어갔을 때")
+    void extExtractTest() {
+        String fileName = "/index.html";
+        String ext = fileParser.fileExtExtract(fileName);
+        assertThat(ext).isEqualTo(".html");
+    }
+
+    @Test
+    @DisplayName("파일 이름이 비정상적인 경우")
+    void extExtractIncorrectTest() {
+       String fileName = "asdfajjjdmfk";
+       assertThatThrownBy(() -> {
+           fileParser.fileExtExtract(fileName);
+       }).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/webserver/RequestTest.java
+++ b/src/test/java/webserver/RequestTest.java
@@ -13,23 +13,32 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class RequestTest {
 
-    static private String httpMessage;
-    static private BufferedReader br;
-
-    @BeforeAll
-    static void beforeAll() {
-        httpMessage = "GET /index.html http/1.1\nConnection: keep-alive\nHost: localhost:8080\n";
-        ByteArrayInputStream bis = new ByteArrayInputStream(httpMessage.getBytes());
-        br = new BufferedReader(new InputStreamReader(bis));
-    }
-
     @Test
     void requestTest() throws IOException {
-        Request request = new Request(br);
+        // given
+        String httpMessage = "GET /index.html http/1.1\nConnection: keep-alive\nHost: localhost:8080\n";
+        ByteArrayInputStream bis = new ByteArrayInputStream(httpMessage.getBytes());
+
+        // when
+        Request request = new HttpRequestParser().getRequest(bis);
+
+        // then
         Assertions.assertThat(request.getMethod()).isEqualTo("GET");
         Assertions.assertThat(request.getPath()).isEqualTo("/index.html");
         Assertions.assertThat(request.getHttpVersion()).isEqualTo("http/1.1");
         Assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
         Assertions.assertThat(request.getHeader("Host")).isEqualTo("localhost:8080");
+    }
+
+    @Test
+    void wrongRequestTest() throws IOException {
+        // given
+        String httpMessage = "GET /index.html http/1.1\nConnection: keep-alive: k\nHost: localhost:8080\n";
+        ByteArrayInputStream bis = new ByteArrayInputStream(httpMessage.getBytes());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> {
+            new HttpRequestParser().getRequest(bis);
+        }).isInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
- mimeType을 Enum 타입으로 선언하여 재사용성 강화
- MimeTypeMapper 클래스를 통해 확장자와 mimeType 매핑
- Content-Type과 반환 되는 파일의 mimeType 일치하게 변환
- RequestTest 예외 유닛 테스트 추가
- HttpRequestParser를 통해 Request 생성자 로직 단순화