### PR TITLE
[week 1-2] 컨텐츠 타입 지원 구현

### DIFF
--- a/src/main/java/http/HttpMethodType.java
+++ b/src/main/java/http/HttpMethodType.java
@@ -1,9 +1,0 @@
-package http;
-
-public enum HttpMethodType {
-    GET,
-    POST,
-    PUT,
-    DELETE,
-    PATCH,
-}

--- a/src/main/java/http/MyHttpHeaders.java
+++ b/src/main/java/http/MyHttpHeaders.java
@@ -26,6 +26,10 @@ public class MyHttpHeaders {
         headers.put(parts[0].trim(), parts[1].trim());
     }
 
+    public void putHeader(String key, String value) {
+        headers.put(key, value);
+    }
+
     public String getHeader(String name) {
         return headers.get(name);
     }

--- a/src/main/java/http/MyHttpRequest.java
+++ b/src/main/java/http/MyHttpRequest.java
@@ -1,19 +1,20 @@
 package http;
 
+import http.enums.HttpMethodType;
 import http.utils.HttpMethodTypeUtil;
 import http.utils.HttpParseUtil;
 
 import java.util.List;
 import java.util.Map;
 
-public class HttpRequest {
-    private HttpMethodType method;
-    private String url;
-    private String version;
+public class MyHttpRequest {
+    private final HttpMethodType method;
+    private final String url;
+    private final String version;
 
-    MyHttpHeaders headers;
+    private MyHttpHeaders headers;
 
-    public HttpRequest(String requestLine, List<String> headerLines) {
+    public MyHttpRequest(String requestLine, List<String> headerLines) {
         String[] reqLineTokens = HttpParseUtil.parseRequestLine(requestLine);
         this.method = HttpMethodTypeUtil.getHttpMethodType(reqLineTokens[0]);
         this.url = reqLineTokens[1];
@@ -37,5 +38,9 @@ public class HttpRequest {
 
     public Map<String, String> getHeaderMap() {
         return headers.getHeaders();
+    }
+
+    public MyHttpHeaders getHeaders() {
+        return headers;
     }
 }

--- a/src/main/java/http/MyHttpResponse.java
+++ b/src/main/java/http/MyHttpResponse.java
@@ -1,0 +1,46 @@
+package http;
+
+import http.enums.HttpStatusType;
+
+public class MyHttpResponse {
+    private final String version;
+    private HttpStatusType statusInfo;
+    private final MyHttpHeaders headers;
+
+    private byte[] body;
+
+    public MyHttpResponse(String version) {
+        this.version = version;
+        this.headers = new MyHttpHeaders();
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public HttpStatusType getStatusType() {
+        return statusInfo;
+    }
+
+    public MyHttpHeaders getHeaders() {
+        return headers;
+    }
+
+    public byte[] getBody() {
+        return body;
+    }
+
+    public void setStatusInfo(HttpStatusType statusInfo) {
+        this.statusInfo = statusInfo;
+    }
+
+    public HttpStatusType getStatusInfo() {
+        return statusInfo;
+    }
+
+    // 바디를 쓰면 Content-Length도 함께 설정해주기
+    public void setBody(byte[] body) {
+        this.body = body;
+        getHeaders().putHeader("Content-Length", String.valueOf(body.length));
+    }
+}

--- a/src/main/java/http/enums/HttpMethodType.java
+++ b/src/main/java/http/enums/HttpMethodType.java
@@ -1,0 +1,14 @@
+package http.enums;
+
+public enum HttpMethodType {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    PATCH,
+
+    HEAD,
+    CONNECT,
+    OPTIONS,
+    TRACE;
+}

--- a/src/main/java/http/enums/HttpStatusType.java
+++ b/src/main/java/http/enums/HttpStatusType.java
@@ -1,0 +1,72 @@
+package http.enums;
+
+// [주의]
+// 자동완성 기능을 많이 활용해서 잘못된 부분이 있을 수 있음.
+// 필요한 응답이 포함되어 있지 않다면 추가
+public enum HttpStatusType {
+    // Informational Responses
+    CONTINUE(100, "Continue"),
+    SWITCHING_PROTOCOLS(101, "Switching Protocols"),
+    PROCESSING(102, "Processing"),
+    EARLY_HINTS(103, "Early Hints"),
+    // Successful Responses
+    OK(200, "OK"),
+    CREATED(201, "Created"),
+    ACCEPTED(202, "Accepted"),
+    NO_CONTENT(204, "No Content"),
+    RESET_CONTENT(205, "Reset Content"),
+    PARTIAL_CONTENT(206, "Partial Content"),
+    MULTI_STATUS(207, "Multi-Status"),
+
+    //Redirection messages
+    MOVED_PERMANENTLY(301, "Moved Permanently"),
+    FOUND(302, "Found"),
+    SEE_OTHER(303, "See Other"),
+    NOT_MODIFIED(304, "Not Modified"),
+    USE_PROXY(305, "Use Proxy"),
+    TEMPORARY_REDIRECT(307, "Temporary Redirect"),
+    PERMANENT_REDIRECT(308, "Permanent Redirect"),
+
+    // Client Error Responses
+    BAD_REQUEST(400, "Bad Request"),
+    UNAUTHORIZED(401, "Unauthorized"),
+    PAYMENT_REQUIRED(402, "Payment Required"),
+    FORBIDDEN(403, "Forbidden"),
+    NOT_FOUND(404, "Not Found"),
+    METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    NOT_ACCEPTABLE(406, "Not Acceptable"),
+    PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
+    REQUEST_TIMEOUT(408, "Request Timeout"),
+    CONFLICT(409, "Conflict"),
+    GONE(410, "Gone"),
+    LENGTH_REQUIRED(411, "Length Required"),
+    PRECONDITION_FAILED(412, "Precondition Failed"),
+    REQUEST_ENTITY_TOO_LARGE(413, "Request Entity Too Large"),
+    REQUEST_URI_TOO_LONG(414, "Request-URI Too Long"),
+    UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+
+    // Server Error Responses
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    NOT_IMPLEMENTED(501, "Not Implemented"),
+    BAD_GATEWAY(502, "Bad Gateway"),
+    SERVICE_UNAVAILABLE(503, "Service Unavailable"),
+    GATEWAY_TIMEOUT(504, "Gateway Timeout"),
+    HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
+    INSUFFICIENT_STORAGE(507, "Insufficient Storage");
+
+    private final int statusCode;
+    private final String message;
+
+    HttpStatusType(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/http/enums/MIMEType.java
+++ b/src/main/java/http/enums/MIMEType.java
@@ -1,0 +1,21 @@
+package http.enums;
+
+public enum MIMEType {
+    html("text/html"),
+    css("text/css"),
+    js("text/javascript"),
+    ico("image/ico"),
+    png("image/png"),
+    jpg("image/jpg"),
+    svg("image/svg+xml");
+
+    private final String mimeType;
+
+    MIMEType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+}

--- a/src/main/java/http/utils/HttpMethodTypeUtil.java
+++ b/src/main/java/http/utils/HttpMethodTypeUtil.java
@@ -1,17 +1,14 @@
 package http.utils;
 
-import http.HttpMethodType;
+import http.enums.HttpMethodType;
 
 public class HttpMethodTypeUtil {
     public static HttpMethodType getHttpMethodType(String httpMethod) {
         String method = httpMethod.toUpperCase();
-        return switch (method) {
-            case "GET" -> HttpMethodType.GET;
-            case "POST" -> HttpMethodType.POST;
-            case "PUT" -> HttpMethodType.PUT;
-            case "DELETE" -> HttpMethodType.DELETE;
-            case "PATCH" -> HttpMethodType.PATCH;
-            default -> throw new RuntimeException("unsupported http method: " + httpMethod);
-        };
+        try {
+            return HttpMethodType.valueOf(method);
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Invalid http method: " + httpMethod);
+        }
     }
 }

--- a/src/main/java/http/utils/HttpResponseMessageBuildUtil.java
+++ b/src/main/java/http/utils/HttpResponseMessageBuildUtil.java
@@ -1,0 +1,35 @@
+package http.utils;
+
+import http.MyHttpResponse;
+import http.enums.HttpStatusType;
+
+import java.nio.charset.StandardCharsets;
+
+public class HttpResponseMessageBuildUtil {
+    public static byte[] build(MyHttpResponse response) {
+        StringBuilder builder = new StringBuilder();
+
+        // startLine
+        HttpStatusType statusType = response.getStatusType();
+        int code = statusType.getStatusCode();
+        String message = statusType.getMessage();
+        String startLine = response.getVersion() + " " + code + " " + message + "\r\n";
+
+        builder.append(startLine);
+        // header
+        for(var entries: response.getHeaders().getHeaders().entrySet()) {
+            String header = entries.getKey();
+            String value = entries.getValue();
+
+            String headerLine = header + ": " + value + "\r\n";
+            builder.append(headerLine);
+        }
+        // 빈 라인
+        builder.append("\r\n");
+
+        // body
+        if(response.getBody() != null)
+            builder.append(new String(response.getBody(), StandardCharsets.UTF_8));
+        return builder.toString().getBytes();
+    }
+}

--- a/src/main/java/http/utils/MimeTypeUtil.java
+++ b/src/main/java/http/utils/MimeTypeUtil.java
@@ -1,0 +1,14 @@
+package http.utils;
+
+import http.enums.MIMEType;
+
+public class MimeTypeUtil {
+    public static MIMEType getMimeType(String mimeTypeName) {
+        try {
+            String name = mimeTypeName.toLowerCase();
+            return MIMEType.valueOf(name);
+        }catch(IllegalArgumentException e) {
+            throw new RuntimeException("not support mimetype " + mimeTypeName);
+        }
+    }
+}

--- a/src/main/java/routehandler/IRouteHandler.java
+++ b/src/main/java/routehandler/IRouteHandler.java
@@ -1,0 +1,9 @@
+package routehandler;
+
+import http.MyHttpRequest;
+import http.MyHttpResponse;
+
+public interface IRouteHandler {
+    boolean canMatch(Object ...args);
+    void handle(MyHttpRequest request, MyHttpResponse response);
+}

--- a/src/main/java/routehandler/RouteHandlerMatcher.java
+++ b/src/main/java/routehandler/RouteHandlerMatcher.java
@@ -1,0 +1,30 @@
+package routehandler;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RouteHandlerMatcher {
+    List<IRouteHandler> routeHandlers;
+
+    public RouteHandlerMatcher() {
+        this.routeHandlers = new ArrayList<>();
+    }
+
+    public RouteHandlerMatcher(IRouteHandler... routeHandlers) {
+        this();
+        this.routeHandlers.addAll(Arrays.asList(routeHandlers));
+    }
+
+    public IRouteHandler getMatchedRouteHandler(String url) {
+        IRouteHandler routeHandler = null;
+        for (IRouteHandler handler : routeHandlers) {
+            if(!handler.canMatch(url)) continue;
+
+            routeHandler = handler;
+            break;
+        }
+
+        return routeHandler;
+    }
+}

--- a/src/main/java/routehandler/StaticResourceHandler.java
+++ b/src/main/java/routehandler/StaticResourceHandler.java
@@ -1,0 +1,46 @@
+package routehandler;
+
+import http.MyHttpRequest;
+import http.MyHttpResponse;
+import http.enums.HttpStatusType;
+import http.enums.MIMEType;
+import http.utils.MimeTypeUtil;
+import utils.FileExtensionUtil;
+import utils.FileReadUtil;
+
+public class StaticResourceHandler implements IRouteHandler {
+
+    private final String STATIC_URL;
+    public StaticResourceHandler(String STATIC_URL) {
+        this.STATIC_URL = STATIC_URL;
+    }
+
+    @Override
+    public boolean canMatch(Object... args) {
+        return true;
+    }
+
+    @Override
+    public void handle(MyHttpRequest request, MyHttpResponse response) {
+        String fileName = request.getUrl();
+        String filePath = STATIC_URL + fileName;
+
+        // 본문 표현
+        byte[] data = FileReadUtil.read(filePath);
+        try {
+            String extension = FileExtensionUtil.getFileExtension(fileName);
+            MIMEType mimeType = MimeTypeUtil.getMimeType(extension);
+            String mimeTypeString = mimeType.getMimeType();
+
+            // TODO 헤더 설정을 처리할 다른 방법이 없는지 고민 ex) 헤더 일괄 처리?
+            // 컨텐츠 타입 설정
+            response.getHeaders().putHeader("Content-Type", mimeTypeString);
+            response.setBody(data);
+
+            response.setStatusInfo(HttpStatusType.OK);
+        } catch (Exception e) {
+            response.setStatusInfo(HttpStatusType.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/utils/FileExtensionUtil.java
+++ b/src/main/java/utils/FileExtensionUtil.java
@@ -1,0 +1,10 @@
+package utils;
+
+public class FileExtensionUtil {
+    public static String getFileExtension(String fileName) {
+        String[] extensions = fileName.split("\\.");
+        // 확장자가 없으면 null 반환
+        if(extensions.length == 1) return null;
+        return extensions[extensions.length - 1];
+    }
+}

--- a/src/main/java/utils/FileReadUtil.java
+++ b/src/main/java/utils/FileReadUtil.java
@@ -1,0 +1,27 @@
+package utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class FileReadUtil {
+    public static byte[] read(String filePath) {
+        File targetFile = new File(filePath);
+
+        byte[] buffer;
+        if(targetFile.exists() && !targetFile.isDirectory()) {
+            int bodyLength = (int)targetFile.length();
+
+            buffer = new byte[bodyLength];
+            try(FileInputStream fis = new FileInputStream(targetFile)) {
+                fis.read(buffer, 0, buffer.length);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            buffer = new byte[0];
+        }
+
+        return buffer;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -4,17 +4,24 @@ import java.io.*;
 import java.net.Socket;
 import java.util.*;
 
-import http.HttpRequest;
+import http.MyHttpRequest;
+import http.MyHttpResponse;
+import http.utils.HttpResponseMessageBuildUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import routehandler.IRouteHandler;
+import routehandler.RouteHandlerMatcher;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    private Socket connection;
+    private final Socket connection;
+    private final RouteHandlerMatcher matcher;
 
-    public RequestHandler(Socket connectionSocket) {
+    public RequestHandler(Socket connectionSocket, RouteHandlerMatcher matcher )
+    {
         this.connection = connectionSocket;
+        this.matcher = matcher;
     }
 
     public void run() {
@@ -22,68 +29,37 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // 모든 입력 데이터 (http) 읽기
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
 
-            // 요청 라인 - http_method, uri, http_version으로 구분됨
             String requestLine = br.readLine();
 
-            // 모든 헤더 라인 읽기
-            // keep-alive 모드에서는 별도로 처리하지 않으면 null 반환하지 않고, 그냥 blocking 된다.
-            // http header / body는 CR LF로 구분되므로, 공백 기준으로 읽지 않을 수도 없음.
-            // readline은 /r or /n이 나오면 새로운 라인으로 판정.
             List<String> headerLines = new ArrayList<>();
             String buffer;
             while (!(buffer = br.readLine()).isEmpty()) {
                 headerLines.add(buffer);
             }
             // body 부분은 나중에 추가적으로 확장
-            HttpRequest request = new HttpRequest(requestLine, headerLines);
+            MyHttpRequest request = new MyHttpRequest(requestLine, headerLines);
+            MyHttpResponse response = new MyHttpResponse(request.getVersion());
 
-            logger.debug("http method: {}", request.getMethod());
-            logger.debug("url: {}", request.getUrl());
-            logger.debug("version: {}", request.getVersion());
-            logger.debug("[headers]: {}", request.getHeaderMap());
+            String url = request.getUrl();
+            IRouteHandler routeHandler = matcher.getMatchedRouteHandler(url);
 
+            routeHandler.handle(request, response);
             DataOutputStream dos = new DataOutputStream(out);
-            // TODO StaticResourceMatcher로 리팩토링
-            File targetFile = new File("./src/main/resources/static" + request.getUrl());
 
-            byte[] body;
-            if(targetFile.exists() && !targetFile.isDirectory()) {
-                int bodyLength = (int)targetFile.length();
-
-                body = new byte[bodyLength];
-                try(FileInputStream fis = new FileInputStream(targetFile)) {
-                    body = new byte[(int) targetFile.length()];
-                    fis.read(body, 0, body.length);
-                }
-            } else {
-                body = new byte[0];
-            }
-
-            response200Header(dos, body.length);
-            responseBody(dos, body);
+            byte[] responseMessage = HttpResponseMessageBuildUtil.build(response);
+            logger.debug(new String(responseMessage));
+            sendResponse(dos, responseMessage);
             logger.debug("send response");
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void sendResponse(DataOutputStream dos, byte[] responseMessage) {
         try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
+            dos.write(responseMessage, 0, responseMessage.length);
             dos.flush();
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -7,6 +7,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import routehandler.RouteHandlerMatcher;
+import routehandler.StaticResourceHandler;
 
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
@@ -21,6 +23,11 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        // RouteHandlerMatcher을 등록, 요청을 만들 때 같이 보내주자.
+        RouteHandlerMatcher matcher = new RouteHandlerMatcher(
+                new StaticResourceHandler("./src/main/resources/static")
+        );
+
         ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(THREAD_POOL_SIZE);
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
@@ -31,7 +38,7 @@ public class WebServer {
             // new socket이 실행되므로, 각 요청마다 다른 처리가 가능.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                executor.submit(new RequestHandler(connection));
+                executor.submit(new RequestHandler(connection, matcher));
             }
         }
     }


### PR DESCRIPTION
- MIME과 Response Status 을 각각 Enum 타입으로 정리하여 문자열 / 숫자로 다룰 때 발생할 수 있는 여러 문제를 방지
- Response 메시지를 별도의 객체로 분리
- 응답 객체로부터 HTTP Response Message를  byte 배열 형태로 생성하는 유틸 기능 ( HttpResponseMessageBuildUtil ) 구현.
- 헤더 / 바디를 따로 작성하던 응답 전송 방식을 한번에 처리하도록 리팩토링 ( HttpResponseMessageBuildUtil 활용 )
- 파일 읽기 기능을 별도의 유틸 메서드로 추출하여 사용
- 각 요청 경로를 RouteHandler로 추상화, RouteHandler을 이용하여 일관되게 요청을 처리할 수 있게 만듬. ( 추후 지속적인 리팩토링 예정 )
